### PR TITLE
Use of method name and adaptation of prototype classes

### DIFF
--- a/src/adaptation.coffee
+++ b/src/adaptation.coffee
@@ -26,7 +26,12 @@ _.extend Context.prototype,
   adapt: (object, trait) ->
     unless object instanceof Object
       throw new Error "Values of type #{typeof object} cannot be adapted."
-    contexts.Default.addAdaptation object, Trait(object), strategies.preserve
+    objectTrait = Trait(object)
+    methods = {}
+    for prop of object
+      methods[prop] = object[prop] unless object.hasOwnProperty(prop)
+    finalTrait = Trait.compose objectTrait, Trait(methods)
+    contexts.Default.addAdaptation object, finalTrait, strategies.preserve
     this.addAdaptation object, trait, strategies.compose
 
   addAdaptation: (object, trait, strategy) ->
@@ -75,11 +80,20 @@ _.extend Manager.prototype,
     this.adaptationChainFor(object)[0].deploy()
     this
 
-  adaptationChainFor: (object) ->
+  adaptationChainFor: (object, methodName) ->
     relevantAdaptations = _.filter this.adaptations, (adaptation) ->
       adaptation.object is object
     if relevantAdaptations.length == 0
       throw new Error "No adaptations found for #{object}"
+
+    if typeof methodName isnt "undefined"
+      _list = []
+      _i = 0
+      while _i < relevantAdaptations.length
+        adaptation = relevantAdaptations[_i]
+        _list.push adaptation if methodName of adaptation.trait
+        _i++
+      relevantAdaptations = _list
     this.policy.order relevantAdaptations
 
 # Define main behaviour of `Adaptation`.

--- a/src/composition.coffee
+++ b/src/composition.coffee
@@ -44,7 +44,7 @@ traceableTrait = (trait) ->
 _.extend Manager.prototype,
 
   orderedMethods: (object, name) ->
-    adaptations = this.adaptationChainFor object
+    adaptations = this.adaptationChainFor object, name
     for adaptation in adaptations
       adaptation.trait[name].value
 


### PR DESCRIPTION
- Use of method name when getting ordered methods
- In the 'adapt' method, add methods from the prototype to the Trait.
  (By default, Trait doesn't take prototype methods when an object is passed to create a new Trait)
